### PR TITLE
[feat/board-search/#38] 게시글 검색 기능 구현

### DIFF
--- a/cmap/src/main/java/com/umc/cmap/domain/board/controller/BoardController.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/board/controller/BoardController.java
@@ -5,6 +5,7 @@ import com.umc.cmap.config.BaseResponse;
 import com.umc.cmap.domain.board.dto.*;
 import com.umc.cmap.domain.board.service.BoardService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
@@ -57,6 +58,12 @@ public class BoardController {
         } else {
             return new BaseResponse<>(boardService.likePost(boardIdx, request.getUserIdx()));
         }
+    }
+
+    @GetMapping("/search")
+    public BaseResponse<BoardListResponse> getBoardBySearch(@PageableDefault(size = 4, sort = "idx", direction = DESC) Pageable pageable,
+                                                            @RequestParam String keyword) throws BaseException {
+        return new BaseResponse<>(boardService.getBoardBySearch(pageable, keyword));
     }
 
 }

--- a/cmap/src/main/java/com/umc/cmap/domain/board/repository/BoardRepository.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/board/repository/BoardRepository.java
@@ -1,15 +1,18 @@
 package com.umc.cmap.domain.board.repository;
 
 import com.umc.cmap.domain.board.entity.Board;
+import com.umc.cmap.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
     Page<Board> findAllByRemovedAtIsNull(Pageable pageable);
     Page<Board> findByIdxInAndRemovedAtIsNull(List<Long> boardIdx, Pageable pageable);
     Page<Board> findByBoardTitleContainingOrBoardContentContainingAndRemovedAtIsNull(String boardTitle, String boardContent, Pageable pageable);
-
+    Long countByUserIdxAndRemovedAtIsNull(Long userIdx);
+    Optional<Board> findAllByUserIdxAndRemovedAtIsNull(Long userIdx);
 }

--- a/cmap/src/main/java/com/umc/cmap/domain/board/repository/BoardRepository.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/board/repository/BoardRepository.java
@@ -10,5 +10,6 @@ import java.util.List;
 public interface BoardRepository extends JpaRepository<Board, Long> {
     Page<Board> findAllByRemovedAtIsNull(Pageable pageable);
     Page<Board> findByIdxInAndRemovedAtIsNull(List<Long> boardIdx, Pageable pageable);
+    Page<Board> findByBoardTitleContainingOrBoardContentContainingAndRemovedAtIsNull(String boardTitle, String boardContent, Pageable pageable);
 
 }

--- a/cmap/src/main/java/com/umc/cmap/domain/board/service/BoardService.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/board/service/BoardService.java
@@ -1,7 +1,6 @@
 package com.umc.cmap.domain.board.service;
 
 import com.umc.cmap.config.BaseException;
-import com.umc.cmap.config.BaseResponse;
 import com.umc.cmap.config.BaseResponseStatus;
 import com.umc.cmap.domain.board.dto.*;
 import com.umc.cmap.domain.board.entity.*;
@@ -44,8 +43,7 @@ public class BoardService {
             boardResponses.add(boardResponse);
         }
         List<TagDto> tagNames = tagRepository.findAllTags();
-        Page<BoardResponse> pagedBoardResponses = new PageImpl<>(boardResponses, pageable, boardPage.getTotalElements());
-        return new BoardListResponse(pagedBoardResponses, tagNames);
+        return new BoardListResponse(new PageImpl<>(boardResponses, pageable, boardPage.getTotalElements()), tagNames);
     }
 
     public BoardListResponse getBoardListWithTags(Pageable pageable, List<Long> tagIdx) throws BaseException {
@@ -58,8 +56,7 @@ public class BoardService {
             BoardResponse boardResponse = new BoardResponse(board.getIdx(), board.getBoardTitle(), board.getBoardContent(), tagList, board.getCreatedAt());
             boardResponses.add(boardResponse);
         }
-        Page<BoardResponse> pagedBoardResponses = new PageImpl<>(boardResponses, pageable, boardPage.getTotalElements());
-        return new BoardListResponse(pagedBoardResponses, tagNames);
+        return new BoardListResponse(new PageImpl<>(boardResponses, pageable, boardPage.getTotalElements()), tagNames);
     }
 
     private List<Long> findBoardIdxByAllTags(List<Long> tagIdxList) {
@@ -188,7 +185,14 @@ public class BoardService {
     }
 
     public BoardListResponse getBoardBySearch(Pageable pageable, String keyword) throws BaseException {
-        Page<Board> boardList = boardRepository.findByBoardTitleContainingOrBoardContentContainingAndRemovedAtIsNull(keyword, keyword, pageable);
+        Page<Board> boardPage = boardRepository.findByBoardTitleContainingOrBoardContentContainingAndRemovedAtIsNull(keyword, keyword, pageable);
+        List<TagDto> tagNames = tagRepository.findAllTags();
+        List<BoardResponse> boardResponses = new ArrayList<>();
+        for (Board board : boardPage) {
+            HashMap<Long, List<HashMap<Long, String>>> tagList = getTagsForBoard(board.getIdx());
+            BoardResponse boardResponse = new BoardResponse(board.getIdx(), board.getBoardTitle(), board.getBoardContent(), tagList, board.getCreatedAt());
+            boardResponses.add(boardResponse);
+        }
+        return new BoardListResponse(new PageImpl<>(boardResponses, pageable, boardPage.getTotalElements()), tagNames);
     }
-
 }

--- a/cmap/src/main/java/com/umc/cmap/domain/board/service/BoardService.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/board/service/BoardService.java
@@ -1,6 +1,7 @@
 package com.umc.cmap.domain.board.service;
 
 import com.umc.cmap.config.BaseException;
+import com.umc.cmap.config.BaseResponse;
 import com.umc.cmap.config.BaseResponseStatus;
 import com.umc.cmap.domain.board.dto.*;
 import com.umc.cmap.domain.board.entity.*;
@@ -183,7 +184,11 @@ public class BoardService {
     public String likePostCancel(Long boardIdx, Long userIdx) throws BaseException {
         LikeBoard likeBoard = likeBoardRepository.findByBoardIdxAndUserIdx(boardIdx, userIdx);
         likeBoardRepository.delete(likeBoard);
-        return "좋아요";
+        return "좋아요 취소";
+    }
+
+    public BoardListResponse getBoardBySearch(Pageable pageable, String keyword) throws BaseException {
+        Page<Board> boardList = boardRepository.findByBoardTitleContainingOrBoardContentContainingAndRemovedAtIsNull(keyword, keyword, pageable);
     }
 
 }

--- a/cmap/src/main/java/com/umc/cmap/domain/board/service/BoardService.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/board/service/BoardService.java
@@ -177,7 +177,7 @@ public class BoardService {
                 .user(user)
                 .build();
         likeBoardRepository.save(likeBoard);
-        return "좋아요";
+        return "좋아요 성공";
     }
 
     @Transactional


### PR DESCRIPTION
## 📢 기능 설명

- 게시글 검색 기능 query 로 치면 like문 사용 (contains)
- 게시글 삭제되지 않은 글만 받아올 수 있도록 함
- 태그 리스트도 반환함. 하지만 현재는 태그를 선택하는 기능은 빼두었음.
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #38 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 테스트가 완료되지 않은 코드입니다. 다른 곳에서 오류가 많이 나서 일단 merge하고 pull 하겠습니다.
- [ ] Board 부분에서는 오류가 아예 없음을 확인해서 일단 올립니다. refactor로 바로 고칠거임

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?