### PR TITLE
[feat/board-add/#54] 메인화면 이미지 작업 및 프리뷰 구현

### DIFF
--- a/cmap/src/main/java/com/umc/cmap/domain/board/controller/BoardController.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/board/controller/BoardController.java
@@ -21,7 +21,7 @@ public class BoardController {
 
 
     @GetMapping
-    public BaseResponse<BoardListResponse> getBoard(@PageableDefault(size = 4, sort = "idx", direction = DESC) Pageable pageable,
+    public BaseResponse<BoardListResponse> getBoard(@PageableDefault(size = 5, sort = "idx", direction = DESC) Pageable pageable,
                                                     @RequestParam(required = false) List<Long> tagIdx) throws BaseException {
         if (tagIdx != null && !tagIdx.isEmpty()) {
             return new BaseResponse<>(boardService.getBoardListWithTags(pageable, tagIdx));
@@ -60,7 +60,7 @@ public class BoardController {
     }
 
     @GetMapping("/search")
-    public BaseResponse<BoardListResponse> getBoardBySearch(@PageableDefault(size = 4, sort = "idx", direction = DESC) Pageable pageable,
+    public BaseResponse<BoardListResponse> getBoardBySearch(@PageableDefault(size = 5, sort = "idx", direction = DESC) Pageable pageable,
                                                             @RequestParam String keyword) throws BaseException {
         return new BaseResponse<>(boardService.getBoardBySearch(pageable, keyword));
     }

--- a/cmap/src/main/java/com/umc/cmap/domain/board/dto/BoardModifyRequest.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/board/dto/BoardModifyRequest.java
@@ -16,4 +16,5 @@ public class BoardModifyRequest {
     private String boardTitle;
     private String boardContent;
     private List<Long> tagList;
+    private List<String> imgList;
 }

--- a/cmap/src/main/java/com/umc/cmap/domain/board/dto/BoardResponse.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/board/dto/BoardResponse.java
@@ -28,7 +28,7 @@ public class BoardResponse {
 
     private String generatePreview(String text, int maxLength) {
         if (text.length() > maxLength) {
-            return text.substring(0, maxLength - 4) + " ...";
+            return text.substring(0, maxLength - 3) + " ..";
         }
         return text;
     }

--- a/cmap/src/main/java/com/umc/cmap/domain/board/dto/BoardResponse.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/board/dto/BoardResponse.java
@@ -16,13 +16,15 @@ public class BoardResponse {
     private String boardTitle;
     private String boardContent;
     private HashMap<Long, List<HashMap<Long, String>>> tagList;
+    private List<String> imgList;
     private LocalDateTime createdAt;
 
-    public BoardResponse(Long idx, String boardTitle, String boardContent, HashMap<Long, List<HashMap<Long, String>>> tagList, LocalDateTime createdAt) {
+    public BoardResponse(Long idx, String boardTitle, String boardContent, HashMap<Long, List<HashMap<Long, String>>> tagList, List<String> imgList, LocalDateTime createdAt) {
         this.idx = idx;
         this.boardTitle = generatePreview(boardTitle, 10);
         this.boardContent = generatePreview(boardContent, 20);
         this.tagList = tagList;
+        this.imgList = imgList;
         this.createdAt = createdAt;
     }
 

--- a/cmap/src/main/java/com/umc/cmap/domain/board/dto/BoardResponse.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/board/dto/BoardResponse.java
@@ -20,9 +20,16 @@ public class BoardResponse {
 
     public BoardResponse(Long idx, String boardTitle, String boardContent, HashMap<Long, List<HashMap<Long, String>>> tagList, LocalDateTime createdAt) {
         this.idx = idx;
-        this.boardTitle = boardTitle;
-        this.boardContent = boardContent;
+        this.boardTitle = generatePreview(boardTitle, 10);
+        this.boardContent = generatePreview(boardContent, 20);
         this.tagList = tagList;
         this.createdAt = createdAt;
+    }
+
+    private String generatePreview(String text, int maxLength) {
+        if (text.length() > maxLength) {
+            return text.substring(0, maxLength - 4) + " ...";
+        }
+        return text;
     }
 }

--- a/cmap/src/main/java/com/umc/cmap/domain/board/dto/BoardWriteRequest.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/board/dto/BoardWriteRequest.java
@@ -14,4 +14,5 @@ public class BoardWriteRequest {
     private String boardTitle;
     private String boardContent;
     private List<Long> tagList;
+    private List<String> imgList;
 }

--- a/cmap/src/main/java/com/umc/cmap/domain/board/entity/BoardImage.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/board/entity/BoardImage.java
@@ -2,6 +2,7 @@ package com.umc.cmap.domain.board.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,4 +20,10 @@ public class BoardImage {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="board_idx")
     private Board board;
+
+    @Builder
+    public BoardImage (String imageUrl, Board board) {
+        this.imageUrl = imageUrl;
+        this.board = board;
+    }
 }

--- a/cmap/src/main/java/com/umc/cmap/domain/board/entity/BoardImage.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/board/entity/BoardImage.java
@@ -1,0 +1,22 @@
+package com.umc.cmap.domain.board.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BoardImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "board_image_idx")
+    private Long idx;
+
+    private String imageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="board_idx")
+    private Board board;
+}

--- a/cmap/src/main/java/com/umc/cmap/domain/board/entity/BoardImage.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/board/entity/BoardImage.java
@@ -15,6 +15,7 @@ public class BoardImage {
     @Column(name = "board_image_idx")
     private Long idx;
 
+    @Column(name = "image_url")
     private String imageUrl;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/cmap/src/main/java/com/umc/cmap/domain/board/repository/BoardImageRepository.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/board/repository/BoardImageRepository.java
@@ -2,6 +2,12 @@ package com.umc.cmap.domain.board.repository;
 
 import com.umc.cmap.domain.board.entity.BoardImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface BoardImageRepository extends JpaRepository<BoardImage, Long> {
+    List<BoardImage> findBoardImageListByBoardIdx(Long boardIdx);
 }

--- a/cmap/src/main/java/com/umc/cmap/domain/board/repository/BoardImageRepository.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/board/repository/BoardImageRepository.java
@@ -1,0 +1,7 @@
+package com.umc.cmap.domain.board.repository;
+
+import com.umc.cmap.domain.board.entity.BoardImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardImageRepository extends JpaRepository<BoardImage, Long> {
+}

--- a/cmap/src/main/java/com/umc/cmap/domain/board/service/BoardService.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/board/service/BoardService.java
@@ -144,6 +144,7 @@ public class BoardService {
         Cafe cafe = cafeRepository.findById(request.getCafeIdx())
                 .orElseThrow(() -> new BaseException(CAFE_NOT_FOUND));
         modifyTagList(request.getTagList(), board);
+        modifyImgList(request.getImgList(), board);
         board.modifyPost(cafe, request.getBoardTitle(), request.getBoardContent());
 
         return "게시글 수정에 성공했습니다.";
@@ -151,6 +152,27 @@ public class BoardService {
 
     private boolean checkUser(Long writer) throws BaseException {
         return writer.equals(authService.getUser().getIdx());
+    }
+
+    private void modifyImgList(List<String> imgList, Board board) throws BaseException {
+        List<BoardImage> existingImgs = boardImageRepository.findBoardImageListByBoardIdx(board.getIdx());
+        for (String imgUrl : imgList) {
+            if (!containsImg(existingImgs, imgUrl)) {
+                boardImageRepository.save(new BoardImage(imgUrl, board));
+            }
+        }
+        for (BoardImage existingImg : existingImgs) {
+            if(!imgList.contains(existingImg.getImageUrl())) {
+                boardImageRepository.delete(existingImg);
+            }
+        }
+    }
+
+    private boolean containsImg(List<BoardImage> boardImages, String imgUrl) {
+        for (BoardImage img : boardImages) {
+            if (img.getImageUrl().equals(imgUrl)) { return true; }
+        }
+        return false;
     }
 
     private void modifyTagList(List<Long> tagList, Board board) throws BaseException {

--- a/cmap/src/main/java/com/umc/cmap/domain/board/service/BoardService.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/board/service/BoardService.java
@@ -1,12 +1,10 @@
 package com.umc.cmap.domain.board.service;
 
+import com.fasterxml.jackson.databind.ser.Serializers;
 import com.umc.cmap.config.BaseException;
 import com.umc.cmap.domain.board.dto.*;
 import com.umc.cmap.domain.board.entity.*;
-import com.umc.cmap.domain.board.repository.BoardRepository;
-import com.umc.cmap.domain.board.repository.BoardTagRepository;
-import com.umc.cmap.domain.board.repository.LikeBoardRepository;
-import com.umc.cmap.domain.board.repository.TagRepository;
+import com.umc.cmap.domain.board.repository.*;
 import com.umc.cmap.domain.cafe.entity.Cafe;
 import com.umc.cmap.domain.cafe.repository.CafeRepository;
 import com.umc.cmap.domain.user.entity.User;
@@ -32,6 +30,7 @@ public class BoardService {
     private final CafeRepository cafeRepository;
     private final LikeBoardRepository likeBoardRepository;
     private final AuthService authService;
+    private final BoardImageRepository boardImageRepository;
 
 
     public BoardListResponse getBoardList(Pageable pageable) throws BaseException {
@@ -100,6 +99,7 @@ public class BoardService {
 
         Board savedBoard = boardRepository.save(board);
         postBoardTagList(request.getTagList(), savedBoard);
+        postBoardImgList(request.getImgList(), savedBoard);
 
         return savedBoard.getIdx();
     }
@@ -110,6 +110,12 @@ public class BoardService {
                     .orElseThrow(() -> new BaseException(TAG_NOT_FOUND));
 
             boardTagRepository.save(new BoardTag(board, tag));
+        }
+    }
+
+    private void postBoardImgList(List<String> imgList, Board board) throws BaseException {
+        for (String img : imgList) {
+            boardImageRepository.save(new BoardImage(img, board));
         }
     }
 

--- a/cmap/src/main/java/com/umc/cmap/domain/board/service/BoardService.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/board/service/BoardService.java
@@ -37,7 +37,8 @@ public class BoardService {
         List<BoardResponse> boardResponses = new ArrayList<>();
         for (Board board : boardPage) {
             HashMap<Long, List<HashMap<Long, String>>> tagList = getTagsForBoard(board.getIdx());
-            BoardResponse boardResponse = new BoardResponse(board.getIdx(), board.getBoardTitle(), board.getBoardContent(), tagList, board.getCreatedAt());
+            List<String> imgList = getImageUrlForMain(board.getIdx());
+            BoardResponse boardResponse = new BoardResponse(board.getIdx(), board.getBoardTitle(), board.getBoardContent(), tagList, imgList, board.getCreatedAt());
             boardResponses.add(boardResponse);
         }
         List<TagDto> tagNames = tagRepository.findAllTags();
@@ -51,7 +52,8 @@ public class BoardService {
         List<BoardResponse> boardResponses = new ArrayList<>();
         for (Board board : boardPage) {
             HashMap<Long, List<HashMap<Long, String>>> tagList = getTagsForBoard(board.getIdx());
-            BoardResponse boardResponse = new BoardResponse(board.getIdx(), board.getBoardTitle(), board.getBoardContent(), tagList, board.getCreatedAt());
+            List<String> imgList = getImageUrlForMain(board.getIdx());
+            BoardResponse boardResponse = new BoardResponse(board.getIdx(), board.getBoardTitle(), board.getBoardContent(), tagList, imgList, board.getCreatedAt());
             boardResponses.add(boardResponse);
         }
         return new BoardListResponse(new PageImpl<>(boardResponses, pageable, boardPage.getTotalElements()), tagNames);
@@ -81,6 +83,22 @@ public class BoardService {
         result.put(boardIdx, tagsList);
         return result;
     }
+
+    private List<String> getImageUrlForMain(Long boardIdx) {
+        List<BoardImage> images = boardImageRepository.findBoardImageListByBoardIdx(boardIdx);
+        int maxImageCount = 3;
+        if (images.size() > maxImageCount) {
+            return images.stream()
+                    .sorted(Comparator.comparing(BoardImage::getIdx))
+                    .limit(maxImageCount)
+                    .map(BoardImage::getImageUrl)
+                    .collect(Collectors.toList());
+        }
+        return images.stream()
+                .map(BoardImage::getImageUrl)
+                .collect(Collectors.toList());
+    }
+
 
     @Transactional
     public Long writeBoard(BoardWriteRequest request) throws BaseException {
@@ -224,7 +242,8 @@ public class BoardService {
         List<BoardResponse> boardResponses = new ArrayList<>();
         for (Board board : boardPage) {
             HashMap<Long, List<HashMap<Long, String>>> tagList = getTagsForBoard(board.getIdx());
-            BoardResponse boardResponse = new BoardResponse(board.getIdx(), board.getBoardTitle(), board.getBoardContent(), tagList, board.getCreatedAt());
+            List<String> imgList = getImageUrlForMain(board.getIdx());
+            BoardResponse boardResponse = new BoardResponse(board.getIdx(), board.getBoardTitle(), board.getBoardContent(), tagList, imgList, board.getCreatedAt());
             boardResponses.add(boardResponse);
         }
         return new BoardListResponse(new PageImpl<>(boardResponses, pageable, boardPage.getTotalElements()), tagNames);

--- a/cmap/src/main/java/com/umc/cmap/domain/board/service/BoardService.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/board/service/BoardService.java
@@ -1,6 +1,5 @@
 package com.umc.cmap.domain.board.service;
 
-import com.fasterxml.jackson.databind.ser.Serializers;
 import com.umc.cmap.config.BaseException;
 import com.umc.cmap.domain.board.dto.*;
 import com.umc.cmap.domain.board.entity.*;


### PR DESCRIPTION
## 📢 기능 설명

### 이미지 작업
- board_image (idx, boardIdx, image_url) table 추가 및 entity 생성
- **게시글 작성**
   - 게시글 작성하면 table에 url 저장 (content tag에도 들어감)
- **게시글 수정**
   - 게시글 수정할 때 사진 삭제 및 추가하면 수정 버튼이 눌린 뒤에 table과 비교하여 추가 및 삭제
   - tag와 동일한 알고리즘
### Preview
- 제목 및 내용 글자 수 제한
- **이미지:** 각 게시글마다 index가 작은 순부터 3개의 사진을 띄울 수 있도록 list로 반환해줌. 이와 관련된 method는 `getImageUrlForMain`


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #54 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [x] 테스트 완료했습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?