### PR TITLE
[refactor/cafe/#104] 카페 수정

### DIFF
--- a/cmap/src/main/java/com/umc/cmap/domain/cafe/controller/response/CafeResponse.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/cafe/controller/response/CafeResponse.java
@@ -73,7 +73,10 @@ public class CafeResponse {
         for (Review review : reviews) {
             totalScore += review.getScore();
         }
-        return totalScore / reviews.size();
+        double average = totalScore / reviews.size();
+        double roundAverage = Math.round(average * 10.0) / 10.0;
+        return roundAverage;
+
     }
 
     private Integer calculateTotalPosts(List<Review> reviews) {

--- a/cmap/src/main/java/com/umc/cmap/domain/cafe/controller/response/CafeTypeResponse.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/cafe/controller/response/CafeTypeResponse.java
@@ -1,0 +1,83 @@
+package com.umc.cmap.domain.cafe.controller.response;
+
+import com.umc.cmap.domain.cafe.entity.Cafe;
+import com.umc.cmap.domain.cmap.entity.Type;
+import com.umc.cmap.domain.review.dto.ReviewResponse;
+import com.umc.cmap.domain.review.dto.ReviewWriterResponse;
+import com.umc.cmap.domain.review.entity.Review;
+import com.umc.cmap.domain.theme.controller.response.CafeThemeResponse;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CafeTypeResponse {
+
+    private Long idx;
+    private String name;
+    private String city;
+    private String district;
+    private String info;
+    private List<CafeThemeResponse> cafeThemes;
+    private String image;
+    private Double cafeLatitude;
+    private Double cafeLongitude;
+
+    private Double averageRating;
+    private Integer totalPosts;
+    private Integer totalReviews;
+    private Type cafeType;
+
+    public CafeTypeResponse(Cafe cafe, List<Review> reviews,Type cafeType) {
+        this.idx = cafe.getIdx();
+        this.name = cafe.getName();
+        this.city = cafe.getCity();
+        this.district = cafe.getDistrict();
+        this.cafeThemes = cafe.getCafeThemes().stream()
+                .map(CafeThemeResponse::new)
+                .collect(Collectors.toList());
+        this.image = cafe.getImage();
+        this.cafeLatitude = cafe.getLocation().getLatitude();
+        this.cafeLongitude = cafe.getLocation().getLongitude();
+        this.averageRating = calculateAverageRating(reviews);
+        this.totalPosts = calculateTotalPosts(reviews);
+        this.totalReviews = reviews.size();
+        this.cafeType = cafeType;
+
+
+    }
+
+
+    private Double calculateAverageRating(List<Review> reviews) {
+        if (reviews.isEmpty()) {
+            return 0.0;
+        }
+        double totalScore = 0.0;
+        for (Review review : reviews) {
+            totalScore += review.getScore();
+        }
+        double average = totalScore / reviews.size();
+        double roundAverage = Math.round(average * 10.0) / 10.0;
+        return roundAverage;
+
+    }
+
+    private Integer calculateTotalPosts(List<Review> reviews) {
+        int totalPosts = 0;
+        for (Review review : reviews) {
+            if (!review.getIsDeleted()) {
+                totalPosts++;
+            }
+        }
+        return totalPosts;
+    }
+
+
+}
+

--- a/cmap/src/main/java/com/umc/cmap/domain/cafe/entity/Cafe.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/cafe/entity/Cafe.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.umc.cmap.config.BaseTimeEntity;
 import com.umc.cmap.domain.board.entity.Board;
+import com.umc.cmap.domain.cmap.entity.Cmap;
 import com.umc.cmap.domain.review.entity.Review;
 import com.umc.cmap.domain.theme.entity.CafeTheme;
 import jakarta.persistence.*;
@@ -45,15 +46,21 @@ public class Cafe extends BaseTimeEntity {
     private String info;
 
     @JsonManagedReference
-    @OneToMany(mappedBy = "cafe", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "cafe", cascade = CascadeType.ALL, fetch = FetchType.EAGER,orphanRemoval = true)
     private List<CafeTheme> cafeThemes = new ArrayList<>();
 
-    @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL,orphanRemoval = true)
     @JoinColumn(name = "location_idx")
     private Location location;
 
-    @OneToMany(mappedBy = "cafe", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "cafe", cascade = CascadeType.ALL, fetch = FetchType.EAGER,orphanRemoval = true)
     private List<Review> reviews = new ArrayList<>();
+
+    @OneToMany(mappedBy = "cafe", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    private List<Board> boards = new ArrayList<>();
+
+    @OneToMany(mappedBy = "cafe", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    private List<Cmap> cmaps = new ArrayList<>();
 
 
     @JsonIgnore

--- a/cmap/src/main/java/com/umc/cmap/domain/filter/service/CafeFilterService.java
+++ b/cmap/src/main/java/com/umc/cmap/domain/filter/service/CafeFilterService.java
@@ -1,21 +1,27 @@
 package com.umc.cmap.domain.filter.service;
 
 import com.umc.cmap.config.BaseException;
-import com.umc.cmap.config.BaseResponse;
 import com.umc.cmap.config.BaseResponseStatus;
 import com.umc.cmap.domain.cafe.controller.response.CafeResponse;
+import com.umc.cmap.domain.cafe.controller.response.CafeTypeResponse;
 import com.umc.cmap.domain.cafe.entity.Cafe;
+import com.umc.cmap.domain.cafe.repository.CafeRepository;
 import com.umc.cmap.domain.cafe.service.CafeService;
-import com.umc.cmap.domain.filter.dto.CafeFilterDto;
-import com.umc.cmap.domain.filter.entity.CafeFilter;
+import com.umc.cmap.domain.cmap.entity.Cmap;
+import com.umc.cmap.domain.cmap.entity.Type;
+import com.umc.cmap.domain.cmap.repository.CmapRepository;
 import com.umc.cmap.domain.filter.repository.CafeFilterRepository;
 import com.umc.cmap.domain.review.entity.Review;
+import com.umc.cmap.domain.review.service.ReviewService;
+import com.umc.cmap.domain.user.entity.User;
+import com.umc.cmap.domain.user.login.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Random;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -23,72 +29,82 @@ public class CafeFilterService {
 
     private final CafeFilterRepository cafefilterRepository;
     private final CafeService cafeService;
+    private final AuthService authService;
+    private final ReviewService reviewService;
+    private final CmapRepository cmapRepository;
+    private final CafeRepository cafeRepository;
 
 
-    public CafeFilterService(CafeFilterRepository cafefilterRepository,CafeService cafeService) {
+    public CafeFilterService(CafeFilterRepository cafefilterRepository, CafeService cafeService, AuthService authService, ReviewService reviewService, CmapRepository cmapRepository, CafeRepository cafeRepository) {
         this.cafefilterRepository = cafefilterRepository;
         this.cafeService=cafeService;
+        this.authService=authService;
+        this.reviewService = reviewService;
+        this.cmapRepository = cmapRepository;
+        this.cafeRepository = cafeRepository;
     }
 
-    public List<CafeResponse> getCafesByTheme(String theme) throws BaseException {
-        List<CafeResponse> cafeResponses = new ArrayList<>();
+    public List<CafeTypeResponse> getCafesByThemes(List<String> themeNames, HttpServletRequest request) throws BaseException {
+        User user = authService.getUser(request);
+        List<CafeTypeResponse> cafeTypeResponses = new ArrayList<>();
 
         try {
-            List<Cafe> cafesWithTheme = cafeService.getCafesByThemes(Collections.singletonList(theme));
+            List<Cafe> cafesWithThemes = cafeService.getCafesByThemes(themeNames);
 
-            for (Cafe cafe : cafesWithTheme) {
-                cafeResponses.add(new CafeResponse(cafe, new ArrayList<>()));
-            }
+            for (Cafe cafe : cafesWithThemes) {
+                List<Review> reviews = reviewService.getCafeReviews(cafe);
 
-            return cafeResponses;
-        } catch (Exception e) {
-            throw new BaseException(BaseResponseStatus.THEME_CAFES_NOT_FOUND);
-        }
-    }
+                Optional<Cmap> cmapOptional = cmapRepository.findByUserAndCafe(user, cafe);
+                Type userType = cmapOptional.map(Cmap::getType).orElse(null);
 
-    public List<CafeResponse> getRandomCafeByTheme(String city, String district, List<String> themeNames) throws BaseException {
-        List<CafeResponse> cafeResponses = new ArrayList<>();
-
-        try {
-            if ((city != null && district != null) && (themeNames != null && themeNames.size() >= 1)) {
-                List<Cafe> cafes = cafeService.getCafesByCityAndDistrictAndThemes(city, district, themeNames);
-
-                for (Cafe cafe : cafes) {
-                    List<String> cafeThemeNames = cafe.getCafeThemes().stream()
-                            .map(cafeTheme -> cafeTheme.getTheme().getName())
-                            .collect(Collectors.toList());
-
-                    if (cafeThemeNames.containsAll(themeNames)) {
-                        cafeResponses.add(new CafeResponse(cafe, new ArrayList<>()));
-                    }
-                }
-            } else if ((city != null && district != null) && (themeNames == null || themeNames.isEmpty())) {
-                List<Cafe> cafes = cafeService.getCafesByCityAndDistrict(city, district);
-                cafeResponses = cafes.stream()
-                        .map(cafe -> new CafeResponse(cafe, new ArrayList<>()))
+                List<String> cafeThemeNames = cafe.getCafeThemes().stream()
+                        .map(cafeTheme -> cafeTheme.getTheme().getName())
                         .collect(Collectors.toList());
-            } else if (themeNames != null && themeNames.size() >= 1 && (city == null || district == null)) {
-                List<Cafe> cafesWithThemes = cafeService.getCafesByThemes(themeNames);
 
-                for (Cafe cafe : cafesWithThemes) {
-                    List<String> cafeThemeNames = cafe.getCafeThemes().stream()
-                            .map(cafeTheme -> cafeTheme.getTheme().getName())
-                            .collect(Collectors.toList());
-
-                    if (cafeThemeNames.containsAll(themeNames)) {
-                        cafeResponses.add(new CafeResponse(cafe, new ArrayList<>()));
-                    }
+                if (cafeThemeNames.containsAll(themeNames)) {
+                    cafeTypeResponses.add(new CafeTypeResponse(cafe, reviews, userType));
                 }
             }
 
-            if (cafeResponses.isEmpty()) {
+            if (cafeTypeResponses.isEmpty()) {
                 throw new BaseException(BaseResponseStatus.THEME_CAFES_NOT_FOUND);
             }
 
-            return cafeResponses;
+            return cafeTypeResponses;
         } catch (Exception e) {
             throw new BaseException(BaseResponseStatus.THEME_CAFES_NOT_FOUND);
         }
     }
+
+    public List<CafeTypeResponse> getRandomCafeByTheme(
+            String city, String district, List<String> themeNames, HttpServletRequest request) throws BaseException {
+        User user = authService.getUser(request);
+
+        List<Cafe> cafes = cafeRepository.findCafesByCityAndDistrict(city, district);
+        List<CafeTypeResponse> cafeTypeResponses = new ArrayList<>();
+
+        for (Cafe cafe : cafes) {
+            List<String> cafeThemeNames = cafe.getCafeThemes().stream()
+                    .map(cafeTheme -> cafeTheme.getTheme().getName())
+                    .collect(Collectors.toList());
+
+            if (cafeThemeNames.containsAll(themeNames)) {
+                List<Review> reviews = reviewService.getCafeReviews(cafe);
+
+                Optional<Cmap> cmapOptional = cmapRepository.findByUserAndCafe(user, cafe);
+                Type userType = cmapOptional.map(Cmap::getType).orElse(null);
+
+                cafeTypeResponses.add(new CafeTypeResponse(cafe, reviews, userType));
+            }
+        }
+
+        if (cafeTypeResponses.isEmpty()) {
+            throw new BaseException(BaseResponseStatus.THEME_CAFES_NOT_FOUND);
+        }
+
+        return cafeTypeResponses;
+    }
+
+
 
 }


### PR DESCRIPTION
📢 기능 설명

- [ ]  cafe 인덱스 삭제시 자식 테이블(board,review,location,cafethemes)의 레코드도 삭제
- [ ] 카페 반환값에 타입 반영
- [ ] 카페 테마로 검색시 테마 여러로도 검색 가능
- [ ] 시/군,구와 테마로 검색할때 모든 조건을 만족해야(!null) 검색되도록 수정

📕 레퍼런스
https://tecoble.techcourse.co.kr/post/2021-08-15-jpa-cascadetype-remove-vs-orphanremoval-true/

연결된 issue
연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요.

close https://github.com/UMCCMAP/server/issues/104




🩷 Approve 하기 전 확인해주세요!


✅ 체크리스트
 PR 제목 규칙 잘 지켰는가?
 추가/수정사항을 설명하였는가?
 이슈넘버를 적었는가?